### PR TITLE
Calendar module

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -40,11 +40,15 @@ class modRaCalendarDownloadHelper
         $e_date = DateTime::createFromFormat('dmYHis', $enddate);
 
         // Set the timeout in seconds for the feed request
+        if ($rsstimeout <= 0)
+        {
+            // If nothing has been set then this is a legacy configuration (pre 0.3.5) so use a default. 
+            $rsstimeout = 30 ;
+        }
         //ini_set('max_execution_time', $rsstimeout);
         ini_set('default_socket_timeout', $rsstimeout);
-
         // First get the data from the Ramblers Site
-         $url = "http://www.ramblers.org.uk/api/lbs/walks?groups=" . $group ;
+        $url = "http://www.ramblers.org.uk/api/lbs/walks?groups=" . $group ;
 
          // Get the JSON information
          $walkdata = file_get_contents($url);

--- a/mod_ra_calendar_download.xml
+++ b/mod_ra_calendar_download.xml
@@ -58,20 +58,7 @@
               <field name="leadingText" type="textarea" default="Leading Text" rows="5" cols="20" label="PRE_TEXT"/>
               <field name="trailingText" type="textarea" default="Trailing Text" rows="5" cols="20" label="POST_TEXT"/>
               <field name="moduleclass_sfx" type="text" default="" label="MOD_ICAL_MODULE_CLASS_SUFFIX" description="Used to Colour / Style the Module" />
-              <field name="rsstimeout" type="list" default="30" required="true" label="Select Timeout" description="RSS Timeout">
-                  <option value="5">5 Seconds</option>
-                  <option value="10">10 Seconds</option>
-                  <option value="15">15 Seconds</option>
-                  <option value="20">20 Seconds</option>
-                  <option value="25">25 Seconds</option>
-                  <option value="30">30 Seconds</option>
-                  <option value="35">35 Seconds</option>
-                  <option value="40">40 Seconds</option>
-                  <option value="45">45 Seconds</option>
-                  <option value="50">50 Seconds</option>
-                  <option value="55">55 Seconds</option>
-                  <option value="60">60 Seconds</option>
-              </field>
+              <field name="rsstimeout" type="text" default="30" required="true" label="Select Timeout" description="RSS Timeout" />
             </fieldset>
         </fields>
     </config>


### PR DESCRIPTION
When adding a new configuration item, unless the settings are re-saved
within the module the components do not receive the default settings.
So these need to be added to the code. In this instance rsstimeout
needs to be set otherwise it will be 0 which is a very short timeout.